### PR TITLE
Fix multi-user database access in web app by disabling SQLite connect…

### DIFF
--- a/src/Kavopici.Core/Data/SqliteWalInterceptor.cs
+++ b/src/Kavopici.Core/Data/SqliteWalInterceptor.cs
@@ -20,7 +20,7 @@ public class SqliteWalInterceptor : DbConnectionInterceptor
     private static void ExecutePragmas(DbConnection connection)
     {
         using var command = connection.CreateCommand();
-        command.CommandText = "PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000;";
+        command.CommandText = "PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000; PRAGMA synchronous=NORMAL;";
         command.ExecuteNonQuery();
     }
 }

--- a/src/Kavopici.Web/Program.cs
+++ b/src/Kavopici.Web/Program.cs
@@ -15,7 +15,7 @@ builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
 
 builder.Services.AddDbContextFactory<KavopiciDbContext>(options =>
-    options.UseSqlite($"Data Source={dbPath}")
+    options.UseSqlite($"Data Source={dbPath};Pooling=False")
         .AddInterceptors(new SqliteWalInterceptor()));
 
 // Core services

--- a/src/Kavopici/Data/SqliteWalInterceptor.cs
+++ b/src/Kavopici/Data/SqliteWalInterceptor.cs
@@ -20,7 +20,7 @@ public class SqliteWalInterceptor : DbConnectionInterceptor
     private static void ExecutePragmas(DbConnection connection)
     {
         using var command = connection.CreateCommand();
-        command.CommandText = "PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000;";
+        command.CommandText = "PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000; PRAGMA synchronous=NORMAL;";
         command.ExecuteNonQuery();
     }
 }


### PR DESCRIPTION
…ion pooling

The Blazor Server app serves all users from a single process. With default connection pooling, Microsoft.Data.Sqlite keeps connections (and their SQLite file handles/WAL read marks) alive after DbContext disposal. This prevents WAL checkpointing and blocks concurrent access, limiting the app to one user at a time.

- Add Pooling=False to the web app's SQLite connection string so connections are truly closed after each operation, releasing all locks immediately
- Add PRAGMA synchronous=NORMAL to both interceptors for better WAL-mode write performance (SQLite-recommended setting for WAL)

The WPF app is unaffected: each user runs their own process with an isolated pool, so inter-process coordination via SQLite file locks works correctly.

https://claude.ai/code/session_017V2PcjSz1XrwYfBjzxPGiW