### PR TITLE
Add retroactive voting for past tasting sessions (#19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,12 @@ Kávopíči je webová aplikace pro kancelářské degustace kávy. Administrát
 - **Tajné hlasování** — detaily směsi se odhalí až po ohodnocení.
 - Hodnocení 1–5 hvězdiček, volitelný komentář a výběr chuťových poznámek (Ovocná, Ořechová, Čokoládová, Karamelová, Květinová, Kořeněná, Citrusová, Medová).
 - Úprava vlastního hodnocení.
+- **Zpětné hlasování** — pokud nebyla nastavena káva dne a uživatel neohodnotil poslední směs, na nástěnce se zobrazí karta pro zpětné hodnocení.
 
 ### Statistiky
 - Souhrnná tabulka směsí (průměr, počet, pražírna, dodavatel) — sortovatelná podle sloupců.
 - **Detail směsi** — rozložení hvězdiček, jednotlivá hodnocení s komentáři a poznámkami.
-- **Moje hodnocení** — historie vlastních hodnocení.
+- **Moje hodnocení** — historie všech degustací s možností zpětného ohodnocení zmeškaných směsí (tajné hlasování platí i zpětně).
 - **Porovnání směsí** — dvě směsi vedle sebe s rozložením hodnocení.
 - **Export CSV** — stažení dat do souboru.
 

--- a/src/Kavopici.Core/Models/SessionWithRating.cs
+++ b/src/Kavopici.Core/Models/SessionWithRating.cs
@@ -1,0 +1,7 @@
+namespace Kavopici.Models;
+
+public record SessionWithRating(
+    TastingSession Session,
+    Rating? UserRating,
+    bool HasRated
+);

--- a/src/Kavopici.Core/Services/ISessionService.cs
+++ b/src/Kavopici.Core/Services/ISessionService.cs
@@ -5,6 +5,7 @@ namespace Kavopici.Services;
 public interface ISessionService
 {
     Task<TastingSession?> GetTodaySessionAsync();
+    Task<TastingSession?> GetMostRecentUnratedSessionAsync(int userId);
     Task<TastingSession> SetBlendOfTheDayAsync(int blendId, string? comment = null);
     Task<List<TastingSession>> GetSessionHistoryAsync();
 }

--- a/src/Kavopici.Core/Services/IStatisticsService.cs
+++ b/src/Kavopici.Core/Services/IStatisticsService.cs
@@ -6,4 +6,5 @@ public interface IStatisticsService
 {
     Task<List<BlendStatistics>> GetBlendStatisticsAsync();
     Task<List<Rating>> GetUserRatingHistoryAsync(int userId);
+    Task<List<SessionWithRating>> GetUserSessionHistoryAsync(int userId);
 }

--- a/src/Kavopici.Core/Services/SessionService.cs
+++ b/src/Kavopici.Core/Services/SessionService.cs
@@ -28,6 +28,18 @@ public class SessionService : ISessionService
             .FirstOrDefaultAsync();
     }
 
+    public async Task<TastingSession?> GetMostRecentUnratedSessionAsync(int userId)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync();
+        return await context.TastingSessions
+            .Where(s => s.Date < Today && s.IsActive)
+            .Where(s => !context.Ratings.Any(r => r.SessionId == s.Id && r.UserId == userId))
+            .Include(s => s.Blend)
+                .ThenInclude(b => b.Supplier)
+            .OrderByDescending(s => s.Date)
+            .FirstOrDefaultAsync();
+    }
+
     public async Task<TastingSession> SetBlendOfTheDayAsync(int blendId, string? comment = null)
     {
         await using var context = await _contextFactory.CreateDbContextAsync();

--- a/src/Kavopici.Web/Components/Pages/Dashboard.razor
+++ b/src/Kavopici.Web/Components/Pages/Dashboard.razor
@@ -13,10 +13,6 @@
 {
     <div class="msg-error">@errorMessage</div>
 }
-@if (statusMessage != null)
-{
-    <div class="msg-success">@statusMessage</div>
-}
 
 @* Highlights *@
 @if (hasHighlights)
@@ -54,19 +50,12 @@
 {
     <div class="loading">Načítání...</div>
 }
-else if (todaySession == null)
-{
-    <div class="panel text-center">
-        <h2>Dnes žádná káva</h2>
-        <p class="text-muted">Administrátor dosud nenastavil dnešní směs.</p>
-    </div>
-}
-else
+else if (todaySession != null)
 {
     <div class="card">
         <h2>Káva dne — @todaySession.Date.ToString("d. M. yyyy")</h2>
 
-        @if (showSecret)
+        @if (showTodaySecret)
         {
             <div class="secret-overlay">
                 <h3>Tajné hlasování</h3>
@@ -81,81 +70,53 @@ else
         }
 
         <div class="mt-16">
-            @if (!hasRated || isEditing)
-            {
-                <div class="form-group">
-                    <label>Vaše hodnocení</label>
-                    <StarRating Value="@selectedStars" ValueChanged="OnStarsChanged" />
-                </div>
-
-                <div class="form-group">
-                    <label>Komentář (volitelný)</label>
-                    <textarea @bind="comment" placeholder="Jak vám káva chutnala?"></textarea>
-                </div>
-
-                <div class="form-group">
-                    <label>Chuťové poznámky</label>
-                    <div class="tasting-notes">
-                        @foreach (var note in availableNotes)
-                        {
-                            <span class="note-tag @(selectedNoteIds.Contains(note.Id) ? "selected" : "")"
-                                  @onclick="() => ToggleNote(note.Id)">
-                                @note.Name
-                            </span>
-                        }
-                    </div>
-                </div>
-
-                <div class="btn-group">
-                    <button class="btn btn-accent" @onclick="SubmitRating"
-                            disabled="@(selectedStars < 1)">
-                        @(isEditing ? "Uložit změny" : "Odeslat hodnocení")
-                    </button>
-                    @if (isEditing)
-                    {
-                        <button class="btn btn-outline" @onclick="CancelEdit">Zrušit</button>
-                    }
-                </div>
-            }
-            else
-            {
-                <div class="panel">
-                    <div class="flex items-center justify-between">
-                        <div>
-                            <StarRating Value="@selectedStars" ReadOnly="true" />
-                            @if (!string.IsNullOrEmpty(comment))
-                            {
-                                <p class="mt-8" style="font-style:italic;color:var(--coffee-medium);">@comment</p>
-                            }
-                            @if (selectedNoteIds.Count > 0)
-                            {
-                                <div class="tasting-notes mt-8">
-                                    @foreach (var note in availableNotes.Where(n => selectedNoteIds.Contains(n.Id)))
-                                    {
-                                        <span class="note-tag selected readonly">@note.Name</span>
-                                    }
-                                </div>
-                            }
-                        </div>
-                        <button class="btn btn-outline" @onclick="StartEdit">Upravit</button>
-                    </div>
-                </div>
-            }
+            <RatingForm SessionId="@todaySession.Id"
+                        BlendId="@todaySession.BlendId"
+                        ExistingRating="@existingRating"
+                        OnRatingSubmitted="OnTodayRatingSubmitted" />
         </div>
+    </div>
+}
+else if (missedSession != null)
+{
+    <div class="card">
+        <h2>Zmeškané hodnocení — @missedSession.Date.ToString("d. M. yyyy")</h2>
+
+        @if (!missedSessionRevealed)
+        {
+            <div class="secret-overlay">
+                <h3>Tajné hlasování</h3>
+                <p>Ohodnoťte kávu před odhalením detailů.</p>
+            </div>
+        }
+        else
+        {
+            <div class="blend-card-wrapper clickable" @onclick="GoToMissedBlend">
+                <BlendCard Blend="missedSession.Blend" SessionComment="@missedSession.Comment" />
+            </div>
+        }
+
+        <div class="mt-16">
+            <RatingForm SessionId="@missedSession.Id"
+                        BlendId="@missedSession.BlendId"
+                        OnRatingSubmitted="OnMissedRatingSubmitted" />
+        </div>
+    </div>
+}
+else
+{
+    <div class="panel text-center">
+        <h2>Dnes žádná káva</h2>
+        <p class="text-muted">Administrátor dosud nenastavil dnešní směs.</p>
     </div>
 }
 
 @code {
     private TastingSession? todaySession;
-    private List<TastingNote> availableNotes = new();
-    private HashSet<int> selectedNoteIds = new();
+    private TastingSession? missedSession;
     private Rating? existingRating;
-
-    private int selectedStars;
-    private string? comment;
-    private bool hasRated;
-    private bool isEditing;
-    private bool isBlendRevealed;
+    private bool todayBlendRevealed;
+    private bool missedSessionRevealed;
     private bool isLoading = true;
 
     private string? topBlendName;
@@ -165,9 +126,8 @@ else
     private bool hasHighlights;
 
     private string? errorMessage;
-    private string? statusMessage;
 
-    private bool showSecret => todaySession != null && !isBlendRevealed;
+    private bool showTodaySecret => todaySession != null && !todayBlendRevealed;
 
     protected override async Task OnInitializedAsync()
     {
@@ -181,12 +141,8 @@ else
         {
             isLoading = true;
             errorMessage = null;
-            statusMessage = null;
 
             todaySession = await SessionService.GetTodaySessionAsync();
-
-            var notes = await RatingService.GetAllTastingNotesAsync();
-            availableNotes = notes;
 
             if (todaySession != null && AppState.CurrentUser != null)
             {
@@ -195,22 +151,19 @@ else
 
                 if (existingRating != null)
                 {
-                    hasRated = true;
-                    isBlendRevealed = true;
-                    selectedStars = existingRating.Stars;
-                    comment = existingRating.Comment;
-
+                    todayBlendRevealed = true;
                     var noteIds = await RatingService.GetRatingNoteIdsAsync(existingRating.Id);
-                    selectedNoteIds = new HashSet<int>(noteIds);
+                    existingRating.RatingTastingNotes = noteIds.Select(id =>
+                        new RatingTastingNote { RatingId = existingRating.Id, TastingNoteId = id }).ToList();
                 }
                 else
                 {
-                    hasRated = false;
-                    isBlendRevealed = false;
-                    selectedStars = 0;
-                    comment = null;
-                    selectedNoteIds.Clear();
+                    todayBlendRevealed = false;
                 }
+            }
+            else if (todaySession == null && AppState.CurrentUser != null)
+            {
+                missedSession = await SessionService.GetMostRecentUnratedSessionAsync(AppState.CurrentUser.Id);
             }
 
             // Highlights
@@ -240,62 +193,18 @@ else
         }
     }
 
-    private void OnStarsChanged(int stars) => selectedStars = stars;
-    private void ToggleNote(int id)
+    private void OnTodayRatingSubmitted()
     {
-        if (!selectedNoteIds.Remove(id))
-            selectedNoteIds.Add(id);
+        todayBlendRevealed = true;
     }
 
-    private async Task SubmitRating()
+    private void OnMissedRatingSubmitted()
     {
-        try
-        {
-            errorMessage = null;
-            if (todaySession == null || AppState.CurrentUser == null) return;
-
-            if (isEditing && existingRating != null)
-            {
-                existingRating = await RatingService.UpdateRatingAsync(existingRating.Id, selectedStars, comment);
-                isEditing = false;
-            }
-            else
-            {
-                existingRating = await RatingService.SubmitRatingAsync(
-                    todaySession.BlendId, AppState.CurrentUser.Id, todaySession.Id, selectedStars, comment);
-            }
-
-            if (selectedNoteIds.Count > 0 && existingRating != null)
-                await RatingService.SetRatingNotesAsync(existingRating.Id, selectedNoteIds.ToList());
-
-            hasRated = true;
-            isBlendRevealed = true;
-            statusMessage = "Vaše hodnocení bylo uloženo.";
-        }
-        catch (Exception ex)
-        {
-            errorMessage = ex.Message;
-        }
-    }
-
-    private void StartEdit()
-    {
-        isEditing = true;
-        hasRated = false;
-    }
-
-    private void CancelEdit()
-    {
-        if (existingRating != null)
-        {
-            selectedStars = existingRating.Stars;
-            comment = existingRating.Comment;
-        }
-        isEditing = false;
-        hasRated = true;
+        missedSessionRevealed = true;
     }
 
     private void GoToTopBlend() => Nav.NavigateTo($"/blend/{topBlendId}");
     private void GoToTodayBlend() => Nav.NavigateTo($"/blend/{todaySession!.BlendId}");
+    private void GoToMissedBlend() => Nav.NavigateTo($"/blend/{missedSession!.BlendId}");
     private void GoToStatistics() => Nav.NavigateTo("/statistics?tab=ratings");
 }

--- a/src/Kavopici.Web/Components/Pages/Statistics.razor
+++ b/src/Kavopici.Web/Components/Pages/Statistics.razor
@@ -75,10 +75,10 @@ else if (tab == 0)
 }
 else
 {
-    @if (userRatings.Count == 0)
+    @if (userSessions.Count == 0)
     {
         <div class="panel text-center">
-            <p class="text-muted">Zatím jste nic nehodnotili.</p>
+            <p class="text-muted">Zatím žádná degustace.</p>
         </div>
     }
     else
@@ -93,18 +93,53 @@ else
                 </tr>
             </thead>
             <tbody>
-                @foreach (var r in userRatings)
+                @foreach (var item in userSessions)
                 {
+                    var sessionId = item.Session.Id;
+                    var isRevealed = item.HasRated || revealedSessions.Contains(sessionId);
+                    var isExpanded = expandedSessions.Contains(sessionId);
+
                     <tr>
-                        <td>@r.Session.Date.ToString("d. M. yyyy")</td>
-                        <td>@r.Blend.Name</td>
+                        <td>@item.Session.Date.ToString("d. M. yyyy")</td>
                         <td>
-                            <span style="color:var(--amber-gold);">
-                                @(new string('\u2605', r.Stars))@(new string('\u2606', MaxStars - r.Stars))
-                            </span>
+                            @if (isRevealed)
+                            {
+                                <strong>@item.Session.Blend.Name</strong>
+                            }
+                            else
+                            {
+                                <em class="text-muted">Tajné hlasování</em>
+                            }
                         </td>
-                        <td class="text-muted">@(r.Comment ?? "—")</td>
+                        <td>
+                            @if (item.HasRated)
+                            {
+                                <span style="color:var(--amber-gold);">
+                                    @(new string('\u2605', item.UserRating!.Stars))@(new string('\u2606', MaxStars - item.UserRating!.Stars))
+                                </span>
+                            }
+                            else if (!isExpanded)
+                            {
+                                <button class="btn btn-outline btn-sm" @onclick="() => ExpandRatingForm(sessionId)">
+                                    Ohodnotit
+                                </button>
+                            }
+                        </td>
+                        <td class="text-muted">@(item.HasRated ? (item.UserRating!.Comment ?? "—") : "—")</td>
                     </tr>
+
+                    @if (!item.HasRated && isExpanded)
+                    {
+                        <tr>
+                            <td colspan="4" class="inline-rating-cell">
+                                <div class="inline-rating-form">
+                                    <RatingForm SessionId="@sessionId"
+                                                BlendId="@item.Session.BlendId"
+                                                OnRatingSubmitted="() => OnRetroRatingSubmitted(sessionId)" />
+                                </div>
+                            </td>
+                        </tr>
+                    }
                 }
             </tbody>
         </table>
@@ -116,7 +151,9 @@ else
 
     private int tab;
     private List<BlendStatistics> blendStats = new();
-    private List<Rating> userRatings = new();
+    private List<SessionWithRating> userSessions = new();
+    private HashSet<int> expandedSessions = new();
+    private HashSet<int> revealedSessions = new();
     private bool isLoading = true;
     private string? errorMessage;
 
@@ -142,10 +179,25 @@ else
             blendStats = await StatisticsService.GetBlendStatisticsAsync();
 
             if (AppState.CurrentUser != null)
-                userRatings = await StatisticsService.GetUserRatingHistoryAsync(AppState.CurrentUser.Id);
+                userSessions = await StatisticsService.GetUserSessionHistoryAsync(AppState.CurrentUser.Id);
         }
         catch (Exception ex) { errorMessage = ex.Message; }
         finally { isLoading = false; }
+    }
+
+    private void ExpandRatingForm(int sessionId)
+    {
+        expandedSessions.Add(sessionId);
+    }
+
+    private async Task OnRetroRatingSubmitted(int sessionId)
+    {
+        revealedSessions.Add(sessionId);
+        expandedSessions.Remove(sessionId);
+
+        // Reload to update the rated status
+        if (AppState.CurrentUser != null)
+            userSessions = await StatisticsService.GetUserSessionHistoryAsync(AppState.CurrentUser.Id);
     }
 
     private void SortBy(string column)

--- a/src/Kavopici.Web/Components/Shared/RatingForm.razor
+++ b/src/Kavopici.Web/Components/Shared/RatingForm.razor
@@ -1,0 +1,181 @@
+@inject IRatingService RatingService
+@inject AppState AppState
+
+@if (errorMessage != null)
+{
+    <div class="msg-error">@errorMessage</div>
+}
+@if (statusMessage != null)
+{
+    <div class="msg-success">@statusMessage</div>
+}
+
+@if (!hasRated || isEditing)
+{
+    <div class="form-group">
+        <label>Vaše hodnocení</label>
+        <StarRating Value="@selectedStars" ValueChanged="OnStarsChanged" />
+    </div>
+
+    <div class="form-group">
+        <label>Komentář (volitelný)</label>
+        <textarea @bind="comment" placeholder="Jak vám káva chutnala?"></textarea>
+    </div>
+
+    <div class="form-group">
+        <label>Chuťové poznámky</label>
+        <div class="tasting-notes">
+            @foreach (var note in availableNotes)
+            {
+                <span class="note-tag @(selectedNoteIds.Contains(note.Id) ? "selected" : "")"
+                      @onclick="() => ToggleNote(note.Id)">
+                    @note.Name
+                </span>
+            }
+        </div>
+    </div>
+
+    <div class="btn-group">
+        <button class="btn btn-accent" @onclick="SubmitRating"
+                disabled="@(selectedStars < 1)">
+            @(isEditing ? "Uložit změny" : "Odeslat hodnocení")
+        </button>
+        @if (isEditing)
+        {
+            <button class="btn btn-outline" @onclick="CancelEdit">Zrušit</button>
+        }
+    </div>
+}
+else
+{
+    <div class="panel">
+        <div class="flex items-center justify-between">
+            <div>
+                <StarRating Value="@selectedStars" ReadOnly="true" />
+                @if (!string.IsNullOrEmpty(comment))
+                {
+                    <p class="mt-8" style="font-style:italic;color:var(--coffee-medium);">@comment</p>
+                }
+                @if (selectedNoteIds.Count > 0)
+                {
+                    <div class="tasting-notes mt-8">
+                        @foreach (var note in availableNotes.Where(n => selectedNoteIds.Contains(n.Id)))
+                        {
+                            <span class="note-tag selected readonly">@note.Name</span>
+                        }
+                    </div>
+                }
+            </div>
+            <button class="btn btn-outline" @onclick="StartEdit">Upravit</button>
+        </div>
+    </div>
+}
+
+@code {
+    [Parameter, EditorRequired] public int SessionId { get; set; }
+    [Parameter, EditorRequired] public int BlendId { get; set; }
+    [Parameter] public Rating? ExistingRating { get; set; }
+    [Parameter] public EventCallback OnRatingSubmitted { get; set; }
+
+    private List<TastingNote> availableNotes = new();
+    private HashSet<int> selectedNoteIds = new();
+    private int selectedStars;
+    private string? comment;
+    private bool hasRated;
+    private bool isEditing;
+    private string? errorMessage;
+    private string? statusMessage;
+
+    private Rating? currentRating;
+
+    protected override async Task OnInitializedAsync()
+    {
+        availableNotes = await RatingService.GetAllTastingNotesAsync();
+        PopulateFromRating(ExistingRating);
+    }
+
+    private void PopulateFromRating(Rating? rating)
+    {
+        currentRating = rating;
+        if (rating != null)
+        {
+            hasRated = true;
+            selectedStars = rating.Stars;
+            comment = rating.Comment;
+
+            if (rating.RatingTastingNotes != null)
+                selectedNoteIds = new HashSet<int>(rating.RatingTastingNotes.Select(rtn => rtn.TastingNoteId));
+            else
+                selectedNoteIds.Clear();
+        }
+        else
+        {
+            hasRated = false;
+            selectedStars = 0;
+            comment = null;
+            selectedNoteIds.Clear();
+        }
+    }
+
+    private void OnStarsChanged(int stars) => selectedStars = stars;
+
+    private void ToggleNote(int id)
+    {
+        if (!selectedNoteIds.Remove(id))
+            selectedNoteIds.Add(id);
+    }
+
+    private async Task SubmitRating()
+    {
+        try
+        {
+            errorMessage = null;
+            if (AppState.CurrentUser == null) return;
+
+            if (isEditing && currentRating != null)
+            {
+                currentRating = await RatingService.UpdateRatingAsync(currentRating.Id, selectedStars, comment);
+                isEditing = false;
+            }
+            else
+            {
+                currentRating = await RatingService.SubmitRatingAsync(
+                    BlendId, AppState.CurrentUser.Id, SessionId, selectedStars, comment);
+            }
+
+            if (selectedNoteIds.Count > 0 && currentRating != null)
+                await RatingService.SetRatingNotesAsync(currentRating.Id, selectedNoteIds.ToList());
+
+            hasRated = true;
+            statusMessage = "Vaše hodnocení bylo uloženo.";
+
+            await OnRatingSubmitted.InvokeAsync();
+        }
+        catch (Exception ex)
+        {
+            errorMessage = ex.Message;
+        }
+    }
+
+    private async Task StartEdit()
+    {
+        if (currentRating != null)
+        {
+            var noteIds = await RatingService.GetRatingNoteIdsAsync(currentRating.Id);
+            selectedNoteIds = new HashSet<int>(noteIds);
+        }
+        isEditing = true;
+        hasRated = false;
+    }
+
+    private void CancelEdit()
+    {
+        if (currentRating != null)
+        {
+            selectedStars = currentRating.Stars;
+            comment = currentRating.Comment;
+        }
+        isEditing = false;
+        hasRated = true;
+    }
+}

--- a/src/Kavopici.Web/wwwroot/css/app.css
+++ b/src/Kavopici.Web/wwwroot/css/app.css
@@ -481,6 +481,19 @@ textarea { resize: vertical; min-height: 60px; }
     color: var(--coffee-dark);
 }
 
+/* === Inline Rating Form (Statistics retroactive voting) === */
+.inline-rating-cell {
+    padding: 0 !important;
+    border-top: none !important;
+}
+.inline-rating-form {
+    background: var(--off-white);
+    border: 1px solid var(--coffee-light);
+    border-radius: 8px;
+    padding: 16px;
+    margin: 8px 0;
+}
+
 /* === Responsive === */
 @media (max-width: 768px) {
     .flavor-wheel-banner .banner-content {


### PR DESCRIPTION
Allow users to vote on past sessions they missed. Dashboard shows a missed vote card when no blend of the day is set. The "Moje hodnocení" tab in Statistics now lists all sessions with inline voting for unrated ones. Secret voting applies to both locations. Extract shared RatingForm component for reuse.