### PR TITLE
Fix SQLite database blocking when shared DB is used by multiple servers

### DIFF
--- a/src/Kavopici.Core/Data/KavopiciDbContextFactory.cs
+++ b/src/Kavopici.Core/Data/KavopiciDbContextFactory.cs
@@ -18,7 +18,7 @@ public class KavopiciDbContextFactory : IDbContextFactory<KavopiciDbContext>
             ?? throw new InvalidOperationException("Není vybrána žádná databáze.");
 
         var options = new DbContextOptionsBuilder<KavopiciDbContext>()
-            .UseSqlite($"Data Source={path}")
+            .UseSqlite($"Data Source={path};Cache=Shared")
             .AddInterceptors(new SqliteWalInterceptor())
             .Options;
 

--- a/src/Kavopici.Core/Data/SqliteWalInterceptor.cs
+++ b/src/Kavopici.Core/Data/SqliteWalInterceptor.cs
@@ -6,7 +6,7 @@ namespace Kavopici.Data;
 public class SqliteWalInterceptor : DbConnectionInterceptor
 {
     private const string Pragmas =
-        "PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000; PRAGMA synchronous=NORMAL;";
+        "PRAGMA journal_mode=WAL; PRAGMA busy_timeout=30000; PRAGMA synchronous=NORMAL;";
 
     public override void ConnectionOpened(DbConnection connection, ConnectionEndEventData eventData)
     {

--- a/src/Kavopici.Web/Components/Pages/Login.razor
+++ b/src/Kavopici.Web/Components/Pages/Login.razor
@@ -138,13 +138,17 @@
             }
 
             isDatabaseNotSelected = false;
-            selectedDatabasePath = dbPath;
 
-            await Task.Run(() =>
+            if (selectedDatabasePath != dbPath)
             {
-                using var db = DbContextFactory.CreateDbContext();
-                db.Database.Migrate();
-            });
+                await Task.Run(async () =>
+                {
+                    await using var db = await DbContextFactory.CreateDbContextAsync();
+                    await db.Database.MigrateAsync();
+                });
+            }
+
+            selectedDatabasePath = dbPath;
 
             var hasUsers = await UserService.HasAnyUsersAsync();
             isFirstRun = !hasUsers;


### PR DESCRIPTION
Increase busy_timeout from 5s to 30s so running servers wait out migration locks instead of failing. Add retry logic to startup migration, switch to async MigrateAsync, guard Login.razor migration to run only once per circuit, and add Cache=Shared for better WAL coordination.