### PR TITLE
Expand rating scale from 1-5 to 1-10 stars

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## About
 
-Kávopíči is a web application for office coffee tastings. An admin sets the "coffee of the day", coworkers rate it (1–5 stars), add a comment and tasting notes, and the app displays summary statistics, leaderboards, and blend comparisons.
+Kávopíči is a web application for office coffee tastings. An admin sets the "coffee of the day", coworkers rate it (1–10 stars), add a comment and tasting notes, and the app displays summary statistics, leaderboards, and blend comparisons.
 
 ### Target users
 
@@ -25,7 +25,7 @@ Kávopíči is a web application for office coffee tastings. An admin sets the "
 - **Coffee flavor wheel** — link to an interactive flavor wheel for better orientation in taste profiles.
 - Multiple "coffees of the day" — admin can set multiple blends for a session, each shown as a separate card.
 - **Secret voting** — blend details are revealed only after rating. Admin notes are visible before voting so users can tell samples apart.
-- Rating 1–5 stars, optional comment, and tasting note selection (Fruity, Nutty, Chocolatey, Caramel, Floral, Spiced, Citrusy, Honey).
+- Rating 1–10 stars, optional comment, and tasting note selection (Fruity, Nutty, Chocolatey, Caramel, Floral, Spiced, Citrusy, Honey).
 - Edit your own rating.
 - **Retroactive voting** — missed blends can be rated later from the "My Ratings" tab in Statistics.
 
@@ -115,7 +115,7 @@ Rating                  TastingNote              RatingTastingNote
 ├── BlendId (FK)        └── Name (unique)        └── TastingNoteId (PK, FK)
 ├── UserId (FK)
 ├── SessionId (FK)
-├── Stars (1–5, check)
+├── Stars (1–10, check)
 ├── Comment?
 └── CreatedAt
 

--- a/src/Kavopici.Core/Data/KavopiciDbContext.cs
+++ b/src/Kavopici.Core/Data/KavopiciDbContext.cs
@@ -58,7 +58,7 @@ public class KavopiciDbContext : DbContext
         {
             e.HasKey(r => r.Id);
             e.Property(r => r.Stars).IsRequired();
-            e.ToTable(t => t.HasCheckConstraint("CK_Rating_Stars", "[Stars] >= 1 AND [Stars] <= 5"));
+            e.ToTable(t => t.HasCheckConstraint("CK_Rating_Stars", "[Stars] >= 1 AND [Stars] <= 10"));
             e.HasIndex(r => new { r.UserId, r.SessionId }).IsUnique();
             e.HasOne(r => r.Blend)
                 .WithMany(b => b.Ratings)

--- a/src/Kavopici.Core/Migrations/20260328120000_ExpandRatingScaleTo10.Designer.cs
+++ b/src/Kavopici.Core/Migrations/20260328120000_ExpandRatingScaleTo10.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Kavopici.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Kavopici.Migrations
 {
     [DbContext(typeof(KavopiciDbContext))]
-    partial class KavopiciDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260328120000_ExpandRatingScaleTo10")]
+    partial class ExpandRatingScaleTo10
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.11");

--- a/src/Kavopici.Core/Migrations/20260328120000_ExpandRatingScaleTo10.cs
+++ b/src/Kavopici.Core/Migrations/20260328120000_ExpandRatingScaleTo10.cs
@@ -1,0 +1,84 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Kavopici.Migrations
+{
+    /// <inheritdoc />
+    public partial class ExpandRatingScaleTo10 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // SQLite doesn't support ALTER TABLE DROP CONSTRAINT, so we rebuild the table
+            // with the new CHECK constraint and double the star values during the copy.
+            migrationBuilder.Sql("PRAGMA foreign_keys=off;");
+
+            migrationBuilder.Sql("""
+                CREATE TABLE "Ratings_new" (
+                    "Id" INTEGER NOT NULL CONSTRAINT "PK_Ratings" PRIMARY KEY AUTOINCREMENT,
+                    "BlendId" INTEGER NOT NULL,
+                    "UserId" INTEGER NOT NULL,
+                    "SessionId" INTEGER NOT NULL,
+                    "Stars" INTEGER NOT NULL,
+                    "Comment" TEXT NULL,
+                    "CreatedAt" TEXT NOT NULL,
+                    CONSTRAINT "CK_Rating_Stars" CHECK ([Stars] >= 1 AND [Stars] <= 10),
+                    CONSTRAINT "FK_Ratings_CoffeeBlends_BlendId" FOREIGN KEY ("BlendId") REFERENCES "CoffeeBlends" ("Id") ON DELETE RESTRICT,
+                    CONSTRAINT "FK_Ratings_TastingSessions_SessionId" FOREIGN KEY ("SessionId") REFERENCES "TastingSessions" ("Id") ON DELETE RESTRICT,
+                    CONSTRAINT "FK_Ratings_Users_UserId" FOREIGN KEY ("UserId") REFERENCES "Users" ("Id") ON DELETE RESTRICT
+                );
+                """);
+
+            migrationBuilder.Sql("""
+                INSERT INTO "Ratings_new" ("Id", "BlendId", "UserId", "SessionId", "Stars", "Comment", "CreatedAt")
+                SELECT "Id", "BlendId", "UserId", "SessionId", "Stars" * 2, "Comment", "CreatedAt" FROM "Ratings";
+                """);
+
+            migrationBuilder.Sql("""DROP TABLE "Ratings";""");
+            migrationBuilder.Sql("""ALTER TABLE "Ratings_new" RENAME TO "Ratings";""");
+
+            migrationBuilder.Sql("""CREATE INDEX "IX_Ratings_BlendId" ON "Ratings" ("BlendId");""");
+            migrationBuilder.Sql("""CREATE INDEX "IX_Ratings_SessionId" ON "Ratings" ("SessionId");""");
+            migrationBuilder.Sql("""CREATE UNIQUE INDEX "IX_Ratings_UserId_SessionId" ON "Ratings" ("UserId", "SessionId");""");
+
+            migrationBuilder.Sql("PRAGMA foreign_keys=on;");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("PRAGMA foreign_keys=off;");
+
+            migrationBuilder.Sql("""
+                CREATE TABLE "Ratings_old" (
+                    "Id" INTEGER NOT NULL CONSTRAINT "PK_Ratings" PRIMARY KEY AUTOINCREMENT,
+                    "BlendId" INTEGER NOT NULL,
+                    "UserId" INTEGER NOT NULL,
+                    "SessionId" INTEGER NOT NULL,
+                    "Stars" INTEGER NOT NULL,
+                    "Comment" TEXT NULL,
+                    "CreatedAt" TEXT NOT NULL,
+                    CONSTRAINT "CK_Rating_Stars" CHECK ([Stars] >= 1 AND [Stars] <= 5),
+                    CONSTRAINT "FK_Ratings_CoffeeBlends_BlendId" FOREIGN KEY ("BlendId") REFERENCES "CoffeeBlends" ("Id") ON DELETE RESTRICT,
+                    CONSTRAINT "FK_Ratings_TastingSessions_SessionId" FOREIGN KEY ("SessionId") REFERENCES "TastingSessions" ("Id") ON DELETE RESTRICT,
+                    CONSTRAINT "FK_Ratings_Users_UserId" FOREIGN KEY ("UserId") REFERENCES "Users" ("Id") ON DELETE RESTRICT
+                );
+                """);
+
+            migrationBuilder.Sql("""
+                INSERT INTO "Ratings_old" ("Id", "BlendId", "UserId", "SessionId", "Stars", "Comment", "CreatedAt")
+                SELECT "Id", "BlendId", "UserId", "SessionId", "Stars" / 2, "Comment", "CreatedAt" FROM "Ratings";
+                """);
+
+            migrationBuilder.Sql("""DROP TABLE "Ratings";""");
+            migrationBuilder.Sql("""ALTER TABLE "Ratings_old" RENAME TO "Ratings";""");
+
+            migrationBuilder.Sql("""CREATE INDEX "IX_Ratings_BlendId" ON "Ratings" ("BlendId");""");
+            migrationBuilder.Sql("""CREATE INDEX "IX_Ratings_SessionId" ON "Ratings" ("SessionId");""");
+            migrationBuilder.Sql("""CREATE UNIQUE INDEX "IX_Ratings_UserId_SessionId" ON "Ratings" ("UserId", "SessionId");""");
+
+            migrationBuilder.Sql("PRAGMA foreign_keys=on;");
+        }
+    }
+}

--- a/src/Kavopici.Core/Models/BlendStatistics.cs
+++ b/src/Kavopici.Core/Models/BlendStatistics.cs
@@ -11,7 +11,7 @@ public record BlendStatistics(
     string SupplierName,
     double AverageRating,
     int RatingCount,
-    int[] Distribution, // index 0-4 for stars 1-5
+    int[] Distribution, // index 0-9 for stars 1-10
     decimal? PricePerKg,
     double? ControversyLevel, // population variance of stars, null when RatingCount < 2
     decimal? PricePerformance, // PricePerKg / AverageRating, null when either is missing/zero

--- a/src/Kavopici.Core/Services/CsvExportService.cs
+++ b/src/Kavopici.Core/Services/CsvExportService.cs
@@ -24,7 +24,7 @@ public class CsvExportService : ICsvExportService
         var stats = await _statisticsService.GetBlendStatisticsAsync();
         var sb = new StringBuilder();
 
-        sb.AppendLine("Název směsi;Pražírna;Původ;Stupeň pražení;Dodavatel;Cena/kg (Kč);Průměrné hodnocení;Počet hodnocení;1★;2★;3★;4★;5★;Kontroverznost;Cena/★");
+        sb.AppendLine("Název směsi;Pražírna;Původ;Stupeň pražení;Dodavatel;Cena/kg (Kč);Průměrné hodnocení;Počet hodnocení;1★;2★;3★;4★;5★;6★;7★;8★;9★;10★;Kontroverznost;Cena/★");
 
         foreach (var s in stats)
         {
@@ -44,6 +44,11 @@ public class CsvExportService : ICsvExportService
                 s.Distribution[2].ToString(),
                 s.Distribution[3].ToString(),
                 s.Distribution[4].ToString(),
+                s.Distribution[5].ToString(),
+                s.Distribution[6].ToString(),
+                s.Distribution[7].ToString(),
+                s.Distribution[8].ToString(),
+                s.Distribution[9].ToString(),
                 s.ControversyLevel?.ToString("F2") ?? "",
                 s.PricePerformance?.ToString("F0") ?? ""
             ));

--- a/src/Kavopici.Core/Services/RatingService.cs
+++ b/src/Kavopici.Core/Services/RatingService.cs
@@ -7,7 +7,7 @@ namespace Kavopici.Services;
 public class RatingService : IRatingService
 {
     private const int MinStars = 1;
-    private const int MaxStars = 5;
+    private const int MaxStars = 10;
 
     private readonly IDbContextFactory<KavopiciDbContext> _contextFactory;
 

--- a/src/Kavopici.Core/Services/StatisticsService.cs
+++ b/src/Kavopici.Core/Services/StatisticsService.cs
@@ -38,10 +38,10 @@ public class StatisticsService : IStatisticsService
 
             // Aggregate all ratings across the group
             var ratings = groupBlends.SelectMany(b => b.Ratings).ToList();
-            var distribution = new int[5];
+            var distribution = new int[10];
             foreach (var r in ratings)
             {
-                if (r.Stars >= 1 && r.Stars <= 5)
+                if (r.Stars >= 1 && r.Stars <= 10)
                     distribution[r.Stars - 1]++;
             }
 

--- a/src/Kavopici.Web/Components/Pages/BlendDetail.razor
+++ b/src/Kavopici.Web/Components/Pages/BlendDetail.razor
@@ -62,7 +62,7 @@ else
         {
             <h3>@L["Heading_RatingDistribution"]</h3>
             var maxCount = blendStats.Distribution.Max();
-            @for (int i = 4; i >= 0; i--)
+            @for (int i = 9; i >= 0; i--)
             {
                 var count = blendStats.Distribution[i];
                 var widthPct = maxCount > 0 ? (count / (double)maxCount) * 100 : 0;

--- a/src/Kavopici.Web/Components/Pages/Comparison.razor
+++ b/src/Kavopici.Web/Components/Pages/Comparison.razor
@@ -131,7 +131,7 @@ else
     {
         if (stats.RatingCount == 0) return;
         var maxCount = stats.Distribution.Max();
-        for (int i = 4; i >= 0; i--)
+        for (int i = 9; i >= 0; i--)
         {
             var count = stats.Distribution[i];
             var widthPct = maxCount > 0 ? (count / (double)maxCount) * 100 : 0;

--- a/src/Kavopici.Web/Components/Pages/Statistics.razor
+++ b/src/Kavopici.Web/Components/Pages/Statistics.razor
@@ -233,7 +233,7 @@ else if (tab == 3)
 }
 
 @code {
-    private const int MaxStars = 5;
+    private const int MaxStars = 10;
 
     private int tab;
     private List<BlendStatistics> blendStats = new();

--- a/src/Kavopici.Web/Components/Shared/ControversyBadge.razor
+++ b/src/Kavopici.Web/Components/Shared/ControversyBadge.razor
@@ -3,8 +3,8 @@
 @if (Level.HasValue)
 {
     var val = Level.Value;
-    var label = val < 0.5 ? L["Badge_Agreement"] : val < 1.5 ? L["Badge_MildDisagreement"] : L["Badge_Disagreement"];
-    var color = val < 0.5 ? "var(--success-green)" : val < 1.5 ? "var(--warning-orange)" : "var(--error-red)";
+    var label = val < 2.0 ? L["Badge_Agreement"] : val < 6.0 ? L["Badge_MildDisagreement"] : L["Badge_Disagreement"];
+    var color = val < 2.0 ? "var(--success-green)" : val < 6.0 ? "var(--warning-orange)" : "var(--error-red)";
     <span style="@($"color:{color};font-weight:600;font-size:{FontSize}px;")">@label</span>
 }
 else if (ShowDash)

--- a/src/Kavopici.Web/Components/Shared/StarRating.razor
+++ b/src/Kavopici.Web/Components/Shared/StarRating.razor
@@ -16,7 +16,7 @@
 </div>
 
 @code {
-    private const int MaxStars = 5;
+    private const int MaxStars = 10;
 
     [Parameter] public int Value { get; set; }
     [Parameter] public EventCallback<int> ValueChanged { get; set; }

--- a/tests/Kavopici.Tests/Services/CsvExportServiceTests.cs
+++ b/tests/Kavopici.Tests/Services/CsvExportServiceTests.cs
@@ -55,7 +55,7 @@ public class CsvExportServiceTests : IDisposable
 
         Assert.Single(lines);
         Assert.StartsWith("Název směsi;", lines[0]);
-        Assert.Contains("5★", lines[0]);
+        Assert.Contains("10★", lines[0]);
         Assert.Contains("Kontroverznost", lines[0]);
         Assert.Contains("Cena/★", lines[0]);
     }
@@ -90,8 +90,13 @@ public class CsvExportServiceTests : IDisposable
         Assert.Equal("0", columns[10]); // 3★
         Assert.Equal("1", columns[11]); // 4★
         Assert.Equal("0", columns[12]); // 5★
-        Assert.Equal("", columns[13]); // ControversyLevel — only 1 rating, null
-        Assert.Equal("", columns[14]); // PricePerformance — no price set
+        Assert.Equal("0", columns[13]); // 6★
+        Assert.Equal("0", columns[14]); // 7★
+        Assert.Equal("0", columns[15]); // 8★
+        Assert.Equal("0", columns[16]); // 9★
+        Assert.Equal("0", columns[17]); // 10★
+        Assert.Equal("", columns[18]); // ControversyLevel — only 1 rating, null
+        Assert.Equal("", columns[19]); // PricePerformance — no price set
     }
 
     [Fact]

--- a/tests/Kavopici.Tests/Services/RatingServiceTests.cs
+++ b/tests/Kavopici.Tests/Services/RatingServiceTests.cs
@@ -52,7 +52,7 @@ public class RatingServiceTests : IDisposable
         await _ratingService.SubmitRatingAsync(session.BlendId, user.Id, session.Id, 4, null);
 
         await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _ratingService.SubmitRatingAsync(session.BlendId, user.Id, session.Id, 5, null));
+            () => _ratingService.SubmitRatingAsync(session.BlendId, user.Id, session.Id, 10, null));
     }
 
     [Fact]
@@ -64,7 +64,7 @@ public class RatingServiceTests : IDisposable
             () => _ratingService.SubmitRatingAsync(session.BlendId, user.Id, session.Id, 0, null));
 
         await Assert.ThrowsAsync<ArgumentException>(
-            () => _ratingService.SubmitRatingAsync(session.BlendId, user.Id, session.Id, 6, null));
+            () => _ratingService.SubmitRatingAsync(session.BlendId, user.Id, session.Id, 11, null));
     }
 
     [Fact]
@@ -96,9 +96,9 @@ public class RatingServiceTests : IDisposable
         var rating = await _ratingService.SubmitRatingAsync(
             session.BlendId, user.Id, session.Id, 3, "OK");
 
-        var updated = await _ratingService.UpdateRatingAsync(rating.Id, 5, "Actually great!");
+        var updated = await _ratingService.UpdateRatingAsync(rating.Id, 10, "Actually great!");
 
-        Assert.Equal(5, updated.Stars);
+        Assert.Equal(10, updated.Stars);
         Assert.Equal("Actually great!", updated.Comment);
     }
 
@@ -135,7 +135,7 @@ public class RatingServiceTests : IDisposable
             () => _ratingService.UpdateRatingAsync(rating.Id, 0, null));
 
         await Assert.ThrowsAsync<ArgumentException>(
-            () => _ratingService.UpdateRatingAsync(rating.Id, 6, null));
+            () => _ratingService.UpdateRatingAsync(rating.Id, 11, null));
     }
 
     [Fact]
@@ -189,11 +189,11 @@ public class RatingServiceTests : IDisposable
             session.BlendId, user.Id, session.Id, 1, null);
         Assert.Equal(1, rating1.Stars);
 
-        // Create a second user to rate the same session with 5 stars
+        // Create a second user to rate the same session with 10 stars
         var user2 = await _userService.CreateUserAsync("User2");
-        var rating5 = await _ratingService.SubmitRatingAsync(
-            session.BlendId, user2.Id, session.Id, 5, null);
-        Assert.Equal(5, rating5.Stars);
+        var rating10 = await _ratingService.SubmitRatingAsync(
+            session.BlendId, user2.Id, session.Id, 10, null);
+        Assert.Equal(10, rating10.Stars);
     }
 
     [Fact]

--- a/tests/Kavopici.Tests/Services/StatisticsServiceTests.cs
+++ b/tests/Kavopici.Tests/Services/StatisticsServiceTests.cs
@@ -48,6 +48,7 @@ public class StatisticsServiceTests : IDisposable
         Assert.Single(stats);
         Assert.Equal(3.0, stats[0].AverageRating);
         Assert.Equal(2, stats[0].RatingCount);
+        Assert.Equal(10, stats[0].Distribution.Length);
         Assert.Equal(0, stats[0].Distribution[0]); // 1 star
         Assert.Equal(1, stats[0].Distribution[1]); // 2 stars
         Assert.Equal(0, stats[0].Distribution[2]); // 3 stars
@@ -121,7 +122,7 @@ public class StatisticsServiceTests : IDisposable
         Assert.Equal("Jan", s.SupplierName);
         Assert.Equal(4.0, s.AverageRating);
         Assert.Equal(1, s.RatingCount);
-        Assert.Equal(new[] { 0, 0, 0, 1, 0 }, s.Distribution);
+        Assert.Equal(new[] { 0, 0, 0, 1, 0, 0, 0, 0, 0, 0 }, s.Distribution);
     }
 
     [Fact]
@@ -142,7 +143,7 @@ public class StatisticsServiceTests : IDisposable
         Assert.Single(stats);
         Assert.Equal(3.0, stats[0].AverageRating);
         Assert.Equal(3, stats[0].RatingCount);
-        Assert.Equal(new[] { 0, 0, 3, 0, 0 }, stats[0].Distribution);
+        Assert.Equal(new[] { 0, 0, 3, 0, 0, 0, 0, 0, 0, 0 }, stats[0].Distribution);
     }
 
     // --- ControversyLevel tests ---


### PR DESCRIPTION
Existing ratings are doubled (1→2, 2→4, ..., 5→10) via a SQLite table rebuild migration. Updates validation, distribution arrays, CSV export, controversy thresholds (×4 for variance scaling), and all UI components.