### PR TITLE
Add recent database paths feature to login page

### DIFF
--- a/src/Kavopici.Core/Services/AppSettingsService.cs
+++ b/src/Kavopici.Core/Services/AppSettingsService.cs
@@ -5,6 +5,8 @@ namespace Kavopici.Services;
 
 public class AppSettingsService : IAppSettingsService
 {
+    private const int MaxRecentPaths = 5;
+
     private static readonly string SettingsDir = Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
         "Kavopici");
@@ -14,6 +16,8 @@ public class AppSettingsService : IAppSettingsService
     private AppSettings _settings = new();
 
     public string? DatabasePath => _settings.DatabasePath;
+
+    public IReadOnlyList<string> RecentDatabasePaths => _settings.RecentDatabasePaths.AsReadOnly();
 
     public void Load()
     {
@@ -33,8 +37,32 @@ public class AppSettingsService : IAppSettingsService
 
     public void SetDatabasePath(string? path)
     {
-        _settings.DatabasePath = string.IsNullOrEmpty(path) ? null : ExpandPath(path);
+        if (string.IsNullOrEmpty(path))
+        {
+            _settings.DatabasePath = null;
+        }
+        else
+        {
+            var expanded = ExpandPath(path);
+            _settings.DatabasePath = expanded;
+
+            _settings.RecentDatabasePaths.RemoveAll(p => string.Equals(p, expanded, StringComparison.OrdinalIgnoreCase));
+            _settings.RecentDatabasePaths.Insert(0, expanded);
+            if (_settings.RecentDatabasePaths.Count > MaxRecentPaths)
+                _settings.RecentDatabasePaths.RemoveRange(MaxRecentPaths, _settings.RecentDatabasePaths.Count - MaxRecentPaths);
+        }
+
         Save();
+    }
+
+    public void RemoveRecentDatabasePath(string path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return;
+
+        var removed = _settings.RecentDatabasePaths.RemoveAll(p => string.Equals(p, path, StringComparison.OrdinalIgnoreCase));
+        if (removed > 0)
+            Save();
     }
 
     public static string ExpandPath(string path)
@@ -81,5 +109,6 @@ public class AppSettingsService : IAppSettingsService
     private class AppSettings
     {
         public string? DatabasePath { get; set; }
+        public List<string> RecentDatabasePaths { get; set; } = new();
     }
 }

--- a/src/Kavopici.Core/Services/IAppSettingsService.cs
+++ b/src/Kavopici.Core/Services/IAppSettingsService.cs
@@ -3,6 +3,8 @@ namespace Kavopici.Services;
 public interface IAppSettingsService
 {
     string? DatabasePath { get; }
+    IReadOnlyList<string> RecentDatabasePaths { get; }
     void SetDatabasePath(string? path);
+    void RemoveRecentDatabasePath(string path);
     void Load();
 }

--- a/src/Kavopici.Web/Components/Pages/Login.razor
+++ b/src/Kavopici.Web/Components/Pages/Login.razor
@@ -46,6 +46,31 @@
                     disabled="@string.IsNullOrWhiteSpace(databasePathInput)">
                 @L["Btn_OpenOrCreateDatabase"]
             </button>
+            @if (AppSettings.RecentDatabasePaths.Count > 0)
+            {
+                <div class="form-group" style="margin-top:16px;">
+                    <label>@L["Label_RecentDatabases"]</label>
+                    <ul style="list-style:none;padding:0;margin:0;">
+                        @foreach (var path in AppSettings.RecentDatabasePaths)
+                        {
+                            <li style="display:flex;align-items:center;gap:8px;margin-bottom:4px;">
+                                <button type="button"
+                                        class="btn"
+                                        style="flex:1;text-align:left;background:none;color:var(--coffee-brown);text-decoration:underline;padding:4px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;min-width:0;"
+                                        title="@path"
+                                        @onclick="() => UseRecentDatabase(path)">
+                                    @path
+                                </button>
+                                <button type="button"
+                                        class="btn"
+                                        style="background:none;color:var(--text-muted);padding:2px 6px;"
+                                        title="@L["Btn_RemoveRecentDatabase"]"
+                                        @onclick="() => RemoveRecentDatabase(path)">×</button>
+                            </li>
+                        }
+                    </ul>
+                </div>
+            }
         </div>
     }
     else if (isFirstRun)
@@ -267,6 +292,17 @@
         isDatabaseNotSelected = true;
         isFirstRun = false;
         errorMessage = null;
+    }
+
+    private void UseRecentDatabase(string path)
+    {
+        databasePathInput = path;
+        errorMessage = null;
+    }
+
+    private void RemoveRecentDatabase(string path)
+    {
+        AppSettings.RemoveRecentDatabasePath(path);
     }
 
     private void SelectUser(User user) => selectedUser = user;

--- a/src/Kavopici.Web/Resources/SharedResources.de.resx
+++ b/src/Kavopici.Web/Resources/SharedResources.de.resx
@@ -24,6 +24,8 @@
   <data name="Login_DatabaseInstruction" xml:space="preserve"><value>Geben Sie den Datenbankpfad ein. Wenn die Datei nicht existiert, wird eine neue erstellt.</value></data>
   <data name="Label_DatabasePath" xml:space="preserve"><value>Datenbankpfad</value></data>
   <data name="Btn_OpenOrCreateDatabase" xml:space="preserve"><value>Datenbank öffnen / erstellen</value></data>
+  <data name="Label_RecentDatabases" xml:space="preserve"><value>Zuletzt verwendete Datenbanken</value></data>
+  <data name="Btn_RemoveRecentDatabase" xml:space="preserve"><value>Aus Liste entfernen</value></data>
   <data name="Heading_Welcome" xml:space="preserve"><value>Willkommen!</value></data>
   <data name="Login_FirstAdminInstruction" xml:space="preserve"><value>Erstellen Sie den ersten Administrator, um zu beginnen.</value></data>
   <data name="Label_AdminName" xml:space="preserve"><value>Administratorname</value></data>

--- a/src/Kavopici.Web/Resources/SharedResources.en.resx
+++ b/src/Kavopici.Web/Resources/SharedResources.en.resx
@@ -24,6 +24,8 @@
   <data name="Login_DatabaseInstruction" xml:space="preserve"><value>Enter the database path. If the file does not exist, a new one will be created.</value></data>
   <data name="Label_DatabasePath" xml:space="preserve"><value>Database path</value></data>
   <data name="Btn_OpenOrCreateDatabase" xml:space="preserve"><value>Open / create database</value></data>
+  <data name="Label_RecentDatabases" xml:space="preserve"><value>Recently used databases</value></data>
+  <data name="Btn_RemoveRecentDatabase" xml:space="preserve"><value>Remove from list</value></data>
   <data name="Heading_Welcome" xml:space="preserve"><value>Welcome!</value></data>
   <data name="Login_FirstAdminInstruction" xml:space="preserve"><value>Create the first administrator to get started.</value></data>
   <data name="Label_AdminName" xml:space="preserve"><value>Administrator name</value></data>

--- a/src/Kavopici.Web/Resources/SharedResources.resx
+++ b/src/Kavopici.Web/Resources/SharedResources.resx
@@ -24,6 +24,8 @@
   <data name="Login_DatabaseInstruction" xml:space="preserve"><value>Zadejte cestu k databázi. Pokud soubor neexistuje, vytvoří se nový.</value></data>
   <data name="Label_DatabasePath" xml:space="preserve"><value>Cesta k databázi</value></data>
   <data name="Btn_OpenOrCreateDatabase" xml:space="preserve"><value>Otevřít / vytvořit databázi</value></data>
+  <data name="Label_RecentDatabases" xml:space="preserve"><value>Naposledy použité databáze</value></data>
+  <data name="Btn_RemoveRecentDatabase" xml:space="preserve"><value>Odstranit ze seznamu</value></data>
   <data name="Heading_Welcome" xml:space="preserve"><value>Vítejte!</value></data>
   <data name="Login_FirstAdminInstruction" xml:space="preserve"><value>Vytvořte prvního administrátora pro zahájení.</value></data>
   <data name="Label_AdminName" xml:space="preserve"><value>Jméno administrátora</value></data>

--- a/src/Kavopici.Web/Resources/SharedResources.sk.resx
+++ b/src/Kavopici.Web/Resources/SharedResources.sk.resx
@@ -24,6 +24,8 @@
   <data name="Login_DatabaseInstruction" xml:space="preserve"><value>Zadajte cestu k databáze. Ak súbor neexistuje, vytvorí sa nový.</value></data>
   <data name="Label_DatabasePath" xml:space="preserve"><value>Cesta k databáze</value></data>
   <data name="Btn_OpenOrCreateDatabase" xml:space="preserve"><value>Otvoriť / vytvoriť databázu</value></data>
+  <data name="Label_RecentDatabases" xml:space="preserve"><value>Naposledy použité databázy</value></data>
+  <data name="Btn_RemoveRecentDatabase" xml:space="preserve"><value>Odstrániť zo zoznamu</value></data>
   <data name="Heading_Welcome" xml:space="preserve"><value>Vitajte!</value></data>
   <data name="Login_FirstAdminInstruction" xml:space="preserve"><value>Vytvorte prvého administrátora pre začatie.</value></data>
   <data name="Label_AdminName" xml:space="preserve"><value>Meno administrátora</value></data>


### PR DESCRIPTION
## Summary
This PR adds functionality to track and display recently used databases on the login page, allowing users to quickly access previously opened databases without re-entering the full path.

## Key Changes
- **UI Enhancement**: Added a "Recently used databases" section on the login page that displays up to 5 recent database paths with individual remove buttons
- **Settings Service**: Extended `AppSettingsService` to manage a list of recent database paths with automatic deduplication and size limiting
- **Database Path Tracking**: Modified `SetDatabasePath()` to automatically add the path to the recent list, removing duplicates and maintaining a maximum of 5 entries
- **Recent Database Management**: Added `RemoveRecentDatabasePath()` method to allow users to remove individual entries from the recent list
- **Interface Updates**: Updated `IAppSettingsService` to expose the new recent paths functionality
- **Localization**: Added translations for "Recently used databases" and "Remove from list" labels in English, German, Czech, and Slovak resource files

## Implementation Details
- Recent database paths are stored in the application settings JSON file alongside the current database path
- The UI displays paths with ellipsis overflow handling and full path tooltips for long paths
- Each recent database entry has a clickable button to load it and a remove button (×) to delete it from the list
- Paths are compared case-insensitively to prevent duplicates across different case variations
- The list is automatically maintained at a maximum of 5 entries, with newest entries at the top

https://claude.ai/code/session_01Fw9JamMKURdxo5gjirvYZ6