### PR TITLE
Claude/random blend and admin tables

### DIFF
--- a/src/Kavopici.Core/Services/ISessionService.cs
+++ b/src/Kavopici.Core/Services/ISessionService.cs
@@ -6,6 +6,7 @@ public interface ISessionService
 {
     Task<List<TastingSession>> GetTodaySessionsAsync();
     Task<TastingSession> AddBlendOfTheDayAsync(int blendId, string? comment = null, decimal doseMultiplier = 1.0m);
+    Task<TastingSession> AddRandomBlendOfTheDayAsync(decimal doseMultiplier = 1.0m);
     Task RemoveBlendOfTheDayAsync(int sessionId);
     Task<TastingSession> SetSessionCommentAsync(int sessionId, string? comment);
     Task<TastingSession> SetSessionDoseMultiplierAsync(int sessionId, decimal doseMultiplier);

--- a/src/Kavopici.Core/Services/SessionService.cs
+++ b/src/Kavopici.Core/Services/SessionService.cs
@@ -63,6 +63,73 @@ public class SessionService : ISessionService
         return session;
     }
 
+    public async Task<TastingSession> AddRandomBlendOfTheDayAsync(decimal doseMultiplier = 1.0m)
+    {
+        var validatedDose = ValidateDoseMultiplier(doseMultiplier);
+
+        await using var context = await _contextFactory.CreateDbContextAsync();
+
+        var activeBlends = await context.CoffeeBlends
+            .Where(b => b.IsActive)
+            .Select(b => new { b.Id, b.SupplierId })
+            .ToListAsync();
+
+        if (activeBlends.Count == 0)
+            throw new InvalidOperationException("Žádné aktivní směsi nejsou k dispozici.");
+
+        var todayBlendIds = await context.TastingSessions
+            .Where(s => s.IsActive && s.Date == Today)
+            .Select(s => s.BlendId)
+            .ToListAsync();
+
+        var candidates = activeBlends.Where(b => !todayBlendIds.Contains(b.Id)).ToList();
+        if (candidates.Count == 0)
+            candidates = activeBlends;
+
+        var windowStart = Today.AddDays(-30);
+        // SQLite can't Sum decimals server-side, so aggregate in-memory (same pattern as StatisticsService.GetSupplierStatisticsAsync).
+        var windowSessions = await context.TastingSessions
+            .Where(s => s.IsActive
+                     && s.Date >= windowStart
+                     && s.Date <= Today)
+            .Select(s => new { s.Blend.SupplierId, s.DoseMultiplier })
+            .ToListAsync();
+        var supplierDoses = windowSessions
+            .GroupBy(x => x.SupplierId)
+            .ToDictionary(g => g.Key, g => g.Sum(x => x.DoseMultiplier));
+
+        var weights = candidates
+            .Select(b => 1.0 / (1.0 + (double)(supplierDoses.TryGetValue(b.SupplierId, out var d) ? d : 0m)))
+            .ToList();
+        var total = weights.Sum();
+        var roll = Random.Shared.NextDouble() * total;
+
+        var pickedBlendId = candidates[^1].Id;
+        var cumulative = 0.0;
+        for (var i = 0; i < candidates.Count; i++)
+        {
+            cumulative += weights[i];
+            if (roll < cumulative) { pickedBlendId = candidates[i].Id; break; }
+        }
+
+        var session = new TastingSession
+        {
+            BlendId = pickedBlendId,
+            Date = Today,
+            IsActive = true,
+            DoseMultiplier = validatedDose,
+            CreatedAt = DateTime.UtcNow
+        };
+
+        context.TastingSessions.Add(session);
+        await context.SaveChangesAsync();
+
+        await context.Entry(session).Reference(s => s.Blend).LoadAsync();
+        await context.Entry(session.Blend).Reference(b => b.Supplier).LoadAsync();
+
+        return session;
+    }
+
     public async Task RemoveBlendOfTheDayAsync(int sessionId)
     {
         await using var context = await _contextFactory.CreateDbContextAsync();

--- a/src/Kavopici.Web/Components/Pages/Admin.razor
+++ b/src/Kavopici.Web/Components/Pages/Admin.razor
@@ -142,6 +142,7 @@
                     <div class="lib-search-panel">
                         <div class="head">
                             <div class="section-label">@L["Admin_AddFromLibrary"]</div>
+                            <button class="btn-icon spin-on-hover" title="@L["Admin_RandomBlend"]" @onclick="AddRandomBlend">🎲</button>
                             <div style="flex:1;"></div>
                             <div style="font-size:11px;color:var(--silver);">@string.Format(L["Admin_AvailableCount"], availableForSession.Count)</div>
                         </div>
@@ -680,6 +681,18 @@
             await SessionService.AddBlendOfTheDayAsync(blendId, null, pendingDoseMultiplier);
             var blend = allBlends.FirstOrDefault(b => b.Id == blendId);
             statusMessage = L["Msg_CoffeeOfDayAdded", blend?.Name ?? ""];
+            await LoadCurrentSessions();
+        }
+        catch (Exception ex) { errorMessage = ex.Message; }
+    }
+
+    private async Task AddRandomBlend()
+    {
+        try
+        {
+            errorMessage = null;
+            var added = await SessionService.AddRandomBlendOfTheDayAsync(pendingDoseMultiplier);
+            statusMessage = L["Msg_RandomBlendAdded", added.Blend?.Name ?? ""];
             await LoadCurrentSessions();
         }
         catch (Exception ex) { errorMessage = ex.Message; }

--- a/src/Kavopici.Web/Components/Pages/Admin.razor
+++ b/src/Kavopici.Web/Components/Pages/Admin.razor
@@ -263,17 +263,17 @@
                 <div class="data-table-wrap"><table class="data-table">
                     <thead>
                         <tr>
-                            <th>@L["Label_Blend"]</th>
-                            <th>@L["Label_Roasting"]</th>
-                            <th>@L["Label_Roaster"]</th>
-                            <th>@L["Admin_BroughtBy"]</th>
-                            <th>@L["Admin_Used"]</th>
-                            <th>@L["Sort_PricePerKg"]</th>
+                            <th class="sortable" @onclick='() => SortLibraryBy("name")'>@L["Label_Blend"]@LibrarySortIndicator("name")</th>
+                            <th class="sortable" @onclick='() => SortLibraryBy("roast")'>@L["Label_Roasting"]@LibrarySortIndicator("roast")</th>
+                            <th class="sortable" @onclick='() => SortLibraryBy("roaster")'>@L["Label_Roaster"]@LibrarySortIndicator("roaster")</th>
+                            <th class="sortable" @onclick='() => SortLibraryBy("supplier")'>@L["Admin_BroughtBy"]@LibrarySortIndicator("supplier")</th>
+                            <th class="sortable" @onclick='() => SortLibraryBy("used")'>@L["Admin_Used"]@LibrarySortIndicator("used")</th>
+                            <th class="sortable" @onclick='() => SortLibraryBy("price")'>@L["Sort_PricePerKg"]@LibrarySortIndicator("price")</th>
                             <th>@L["Label_Actions"]</th>
                         </tr>
                     </thead>
                     <tbody>
-                        @foreach (var b in FilteredLibraryBlends())
+                        @foreach (var b in SortedFilteredLibraryBlends())
                         {
                             <tr>
                                 @if (editingBlendId == b.Id)
@@ -376,14 +376,14 @@
                 <div class="data-table-wrap"><table class="data-table">
                     <thead>
                         <tr>
-                            <th>@L["Label_Name"]</th>
-                            <th>@L["Label_Role"]</th>
-                            <th>@L["Admin_RatedCount"]</th>
+                            <th class="sortable" @onclick='() => SortAdminUsersBy("name")'>@L["Label_Name"]@AdminUserSortIndicator("name")</th>
+                            <th class="sortable" @onclick='() => SortAdminUsersBy("role")'>@L["Label_Role"]@AdminUserSortIndicator("role")</th>
+                            <th class="sortable" @onclick='() => SortAdminUsersBy("rated")'>@L["Admin_RatedCount"]@AdminUserSortIndicator("rated")</th>
                             <th>@L["Label_Actions"]</th>
                         </tr>
                     </thead>
                     <tbody>
-                        @foreach (var u in allUsers)
+                        @foreach (var u in SortedUsers())
                         {
                             <tr>
                                 <td>
@@ -474,6 +474,59 @@
             || b.Roaster.Contains(s, StringComparison.OrdinalIgnoreCase)
             || (b.Supplier != null && b.Supplier.Name.Contains(s, StringComparison.OrdinalIgnoreCase))
             || (b.Origin != null && b.Origin.Contains(s, StringComparison.OrdinalIgnoreCase))).ToList();
+    }
+
+    private string librarySortKey = "name";
+    private char librarySortDir = 'a';
+
+    private void SortLibraryBy(string key)
+    {
+        if (librarySortKey == key) librarySortDir = librarySortDir == 'd' ? 'a' : 'd';
+        else { librarySortKey = key; librarySortDir = 'd'; }
+    }
+
+    private string LibrarySortIndicator(string key) =>
+        librarySortKey == key ? (librarySortDir == 'd' ? " ↓" : " ↑") : "";
+
+    private IEnumerable<CoffeeBlend> SortedFilteredLibraryBlends()
+    {
+        var src = FilteredLibraryBlends();
+        IEnumerable<CoffeeBlend> q = librarySortKey switch
+        {
+            "name"     => src.OrderBy(b => b.Name),
+            "roast"    => src.OrderBy(b => (int)b.RoastLevel),
+            "roaster"  => src.OrderBy(b => b.Roaster),
+            "supplier" => src.OrderBy(b => b.Supplier != null ? b.Supplier.Name : ""),
+            "used"     => src.OrderBy(b => blendUsageCounts.GetValueOrDefault(b.Id, 0m)),
+            "price"    => src.OrderBy(b => b.PricePerKg.HasValue ? 0 : 1)
+                             .ThenBy(b => b.PricePerKg),
+            _          => src.OrderBy(b => b.Name)
+        };
+        return librarySortDir == 'd' ? q.Reverse() : q;
+    }
+
+    private string adminUserSortKey = "name";
+    private char adminUserSortDir = 'a';
+
+    private void SortAdminUsersBy(string key)
+    {
+        if (adminUserSortKey == key) adminUserSortDir = adminUserSortDir == 'd' ? 'a' : 'd';
+        else { adminUserSortKey = key; adminUserSortDir = 'd'; }
+    }
+
+    private string AdminUserSortIndicator(string key) =>
+        adminUserSortKey == key ? (adminUserSortDir == 'd' ? " ↓" : " ↑") : "";
+
+    private IEnumerable<User> SortedUsers()
+    {
+        IEnumerable<User> q = adminUserSortKey switch
+        {
+            "name"  => allUsers.OrderBy(u => u.Name),
+            "role"  => allUsers.OrderBy(u => u.IsAdmin),
+            "rated" => allUsers.OrderBy(u => userVoteCounts.GetValueOrDefault(u.Id, 0)),
+            _       => allUsers.OrderBy(u => u.Name)
+        };
+        return adminUserSortDir == 'd' ? q.Reverse() : q;
     }
 
     protected override async Task OnInitializedAsync()

--- a/src/Kavopici.Web/Components/Pages/Statistics.razor
+++ b/src/Kavopici.Web/Components/Pages/Statistics.razor
@@ -407,13 +407,13 @@ else if (tab == 2)
         <div class="data-table-wrap"><table class="data-table">
             <thead>
                 <tr>
-                    <th>@L["Label_Supplier"]</th>
-                    <th>@L["Stats_TotalDoses"]</th>
-                    <th>@L["Stats_Last30DaysDoses"]</th>
+                    <th class="sortable" @onclick='() => SortSuppliersBy("name")'>@L["Label_Supplier"]@SupplierSortIndicator("name")</th>
+                    <th class="sortable" @onclick='() => SortSuppliersBy("total")'>@L["Stats_TotalDoses"]@SupplierSortIndicator("total")</th>
+                    <th class="sortable" @onclick='() => SortSuppliersBy("last30")'>@L["Stats_Last30DaysDoses"]@SupplierSortIndicator("last30")</th>
                 </tr>
             </thead>
             <tbody>
-                @foreach (var stat in supplierStats)
+                @foreach (var stat in SortedSupplierStats())
                 {
                     <tr>
                         <td><strong>@stat.SupplierName</strong></td>
@@ -499,6 +499,9 @@ else if (tab == 3)
     private string userSortKey = "votes";
     private char userSortDir = 'd';
 
+    private string supplierSortKey = "total";
+    private char supplierSortDir = 'd';
+
     private void SortUsersBy(string key)
     {
         if (userSortKey == key) userSortDir = userSortDir == 'd' ? 'a' : 'd';
@@ -507,6 +510,27 @@ else if (tab == 3)
 
     private string UserSortIndicator(string key) =>
         userSortKey == key ? (userSortDir == 'd' ? " ↓" : " ↑") : "";
+
+    private void SortSuppliersBy(string key)
+    {
+        if (supplierSortKey == key) supplierSortDir = supplierSortDir == 'd' ? 'a' : 'd';
+        else { supplierSortKey = key; supplierSortDir = 'd'; }
+    }
+
+    private string SupplierSortIndicator(string key) =>
+        supplierSortKey == key ? (supplierSortDir == 'd' ? " ↓" : " ↑") : "";
+
+    private IEnumerable<SupplierStatistics> SortedSupplierStats()
+    {
+        IEnumerable<SupplierStatistics> q = supplierSortKey switch
+        {
+            "name"   => supplierStats.OrderBy(s => s.SupplierName),
+            "total"  => supplierStats.OrderBy(s => s.TotalDoses),
+            "last30" => supplierStats.OrderBy(s => s.Last30DaysDoses),
+            _        => supplierStats.OrderBy(s => s.SupplierName)
+        };
+        return supplierSortDir == 'd' ? q.Reverse() : q;
+    }
 
     private IEnumerable<UserStatistics> SortedUserStats()
     {

--- a/src/Kavopici.Web/Components/Pages/Statistics.razor
+++ b/src/Kavopici.Web/Components/Pages/Statistics.razor
@@ -157,6 +157,7 @@ else if (tab == 0)
                     <option value="my">@L["Sort_MyRating"]</option>
                     <option value="n">@L["Sort_VoteCount"]</option>
                     <option value="ppk">@L["Sort_PricePerKg"]</option>
+                    <option value="pps">@L["Label_PricePerStar"]</option>
                     <option value="ctrl">@L["Sort_Controversy"]</option>
                     <option value="name">@L["Label_Blend"]</option>
                 </select>
@@ -172,6 +173,7 @@ else if (tab == 0)
                     <div class="text-center">@L["Col_Avg"]</div>
                     <div class="text-right">@L["Col_Votes"]</div>
                     <div class="text-right">@L["Sort_PricePerKg"]</div>
+                    <div class="text-right">@L["Label_PricePerStar"]</div>
                     <div>@L["Label_Controversy"]</div>
                     <div>@L["Col_YouVsAvg"]</div>
                 </div>
@@ -203,6 +205,9 @@ else if (tab == 0)
                         <div class="text-right text-medium">@r.RatingCount×</div>
                         <div class="text-right" style="font-family:Georgia,serif;font-size:14px;color:var(--coffee-dark);">
                             @(r.PricePerKg.HasValue ? r.PricePerKg.Value.ToString("F0") : "—")
+                        </div>
+                        <div class="text-right" style="font-family:Georgia,serif;font-size:14px;color:var(--coffee-dark);">
+                            @(r.PricePerformance.HasValue ? r.PricePerformance.Value.ToString("F0") : "—")
                         </div>
                         <div>
                             <ControversyBadge Level="r.ControversyLevel" Gauge="true" />
@@ -605,6 +610,7 @@ else if (tab == 3)
             "name" => list.OrderBy(r => r.BlendName),
             "n"    => list.OrderByDescending(r => r.RatingCount),
             "ppk"  => list.OrderByDescending(r => r.PricePerKg ?? 0),
+            "pps"  => list.OrderByDescending(r => r.PricePerformance ?? 0),
             "ctrl" => list.OrderByDescending(r => r.ControversyLevel ?? -1),
             "my"   => list.OrderByDescending(r => myStarsByBlend.GetValueOrDefault(r.BlendId, 0)),
             _      => list.OrderByDescending(r => r.AverageRating),

--- a/src/Kavopici.Web/Resources/SharedResources.de.resx
+++ b/src/Kavopici.Web/Resources/SharedResources.de.resx
@@ -216,6 +216,8 @@
   <data name="Msg_CleanupMarkedDone" xml:space="preserve"><value>Als erledigt markiert.</value></data>
   <data name="Msg_CleanupMarkedNotDone" xml:space="preserve"><value>Als nicht erledigt markiert.</value></data>
   <data name="Err_NoActiveUsersForCleanup" xml:space="preserve"><value>Keine aktiven Benutzer.</value></data>
+  <data name="Msg_RandomBlendAdded" xml:space="preserve"><value>Zufällig hinzugefügt: {0}</value></data>
+  <data name="Err_NoBlendsAvailable" xml:space="preserve"><value>Keine aktiven Mischungen verfügbar.</value></data>
 
   <!-- Brand & flavor wheel URL (theme-aware via _Tea suffix) -->
   <data name="Brand_AppName" xml:space="preserve"><value>KÁVOPÍČI</value></data>
@@ -419,6 +421,8 @@
   <data name="Admin_AutoCleanupDesc" xml:space="preserve"><value>Wir weisen jedem Kaffee zufällig jemanden zum Aufräumen zu. Nie zweimal hintereinander dieselbe Person. Du kannst oben manuell überschreiben.</value></data>
   <data name="Admin_RerollAll" xml:space="preserve"><value>🎲 Neu würfeln</value></data>
   <data name="Admin_RerollOne" xml:space="preserve"><value>Aufräumen für diesen Kaffee neu würfeln</value></data>
+  <data name="Admin_RandomBlend" xml:space="preserve"><value>Zufälligen Kaffee hinzufügen (gleicht Lieferantendosen über die letzten 30 Tage aus)</value></data>
+  <data name="Admin_RandomBlend_Tea" xml:space="preserve"><value>Zufälligen Tee hinzufügen (gleicht Lieferantendosen über die letzten 30 Tage aus)</value></data>
   <data name="Admin_AddBlendBtn" xml:space="preserve"><value>+ Neuer Kaffee</value></data>
   <data name="Admin_AddBlendBtn_Tea" xml:space="preserve"><value>+ Neuer Tee</value></data>
   <data name="Admin_InviteBtn" xml:space="preserve"><value>+ Einladen</value></data>

--- a/src/Kavopici.Web/Resources/SharedResources.en.resx
+++ b/src/Kavopici.Web/Resources/SharedResources.en.resx
@@ -216,6 +216,8 @@
   <data name="Msg_CleanupMarkedDone" xml:space="preserve"><value>Marked as done.</value></data>
   <data name="Msg_CleanupMarkedNotDone" xml:space="preserve"><value>Marked as not done.</value></data>
   <data name="Err_NoActiveUsersForCleanup" xml:space="preserve"><value>No active users.</value></data>
+  <data name="Msg_RandomBlendAdded" xml:space="preserve"><value>Randomly added: {0}</value></data>
+  <data name="Err_NoBlendsAvailable" xml:space="preserve"><value>No active blends are available.</value></data>
 
   <!-- Brand & flavor wheel URL (theme-aware via _Tea suffix) -->
   <data name="Brand_AppName" xml:space="preserve"><value>KÁVOPÍČI</value></data>
@@ -419,6 +421,8 @@
   <data name="Admin_AutoCleanupDesc" xml:space="preserve"><value>We randomly assign cleanup to each coffee. Never the same person twice in a row. You can override above.</value></data>
   <data name="Admin_RerollAll" xml:space="preserve"><value>🎲 Reroll</value></data>
   <data name="Admin_RerollOne" xml:space="preserve"><value>Reroll cleanup for this coffee</value></data>
+  <data name="Admin_RandomBlend" xml:space="preserve"><value>Add a random coffee (balances supplier doses over the last 30 days)</value></data>
+  <data name="Admin_RandomBlend_Tea" xml:space="preserve"><value>Add a random tea (balances supplier doses over the last 30 days)</value></data>
   <data name="Admin_AddBlendBtn" xml:space="preserve"><value>+ New coffee</value></data>
   <data name="Admin_AddBlendBtn_Tea" xml:space="preserve"><value>+ New tea</value></data>
   <data name="Admin_InviteBtn" xml:space="preserve"><value>+ Invite</value></data>

--- a/src/Kavopici.Web/Resources/SharedResources.resx
+++ b/src/Kavopici.Web/Resources/SharedResources.resx
@@ -314,6 +314,8 @@
   <data name="Admin_AutoCleanupDesc" xml:space="preserve"><value>Náhodně přidělíme úklid každé kávě. Nikdy stejnou osobu dvakrát po sobě. Můžeš ručně přepsat výše.</value></data>
   <data name="Admin_RerollAll" xml:space="preserve"><value>🎲 Přerolovat</value></data>
   <data name="Admin_RerollOne" xml:space="preserve"><value>Přerolovat úklid pro tuto kávu</value></data>
+  <data name="Admin_RandomBlend" xml:space="preserve"><value>Přidat náhodnou kávu (vyrovnává dávky dodavatelů za 30 dní)</value></data>
+  <data name="Admin_RandomBlend_Tea" xml:space="preserve"><value>Přidat náhodný čaj (vyrovnává dávky dodavatelů za 30 dní)</value></data>
   <data name="Admin_AddBlendBtn" xml:space="preserve"><value>+ Nová káva</value></data>
   <data name="Admin_AddBlendBtn_Tea" xml:space="preserve"><value>+ Nový čaj</value></data>
   <data name="Admin_InviteBtn" xml:space="preserve"><value>+ Pozvat</value></data>
@@ -382,6 +384,8 @@
   <data name="Btn_CleanupDone" xml:space="preserve"><value>Uklizeno</value></data>
   <data name="Btn_CleanupNotDone" xml:space="preserve"><value>Neuklizeno</value></data>
   <data name="Msg_CleanupAssigned" xml:space="preserve"><value>Uklízeč vybrán: {0}</value></data>
+  <data name="Msg_RandomBlendAdded" xml:space="preserve"><value>Náhodně přidáno: {0}</value></data>
+  <data name="Err_NoBlendsAvailable" xml:space="preserve"><value>Žádné aktivní směsi nejsou k dispozici.</value></data>
   <data name="Msg_CleanupCleared" xml:space="preserve"><value>Uklízeč zrušen.</value></data>
   <data name="Msg_CleanupMarkedDone" xml:space="preserve"><value>Označeno jako uklizeno.</value></data>
   <data name="Msg_CleanupMarkedNotDone" xml:space="preserve"><value>Označeno jako neuklizeno.</value></data>

--- a/src/Kavopici.Web/Resources/SharedResources.sk.resx
+++ b/src/Kavopici.Web/Resources/SharedResources.sk.resx
@@ -216,6 +216,8 @@
   <data name="Msg_CleanupMarkedDone" xml:space="preserve"><value>Označené ako upratané.</value></data>
   <data name="Msg_CleanupMarkedNotDone" xml:space="preserve"><value>Označené ako neupratané.</value></data>
   <data name="Err_NoActiveUsersForCleanup" xml:space="preserve"><value>Žiadni aktívni používatelia.</value></data>
+  <data name="Msg_RandomBlendAdded" xml:space="preserve"><value>Náhodne pridané: {0}</value></data>
+  <data name="Err_NoBlendsAvailable" xml:space="preserve"><value>Žiadne aktívne zmesi nie sú k dispozícii.</value></data>
 
   <!-- Brand & flavor wheel URL (theme-aware via _Tea suffix) -->
   <data name="Brand_AppName" xml:space="preserve"><value>KÁVOPÍČI</value></data>
@@ -419,6 +421,8 @@
   <data name="Admin_AutoCleanupDesc" xml:space="preserve"><value>Náhodne pridelíme upratovanie každej káve. Nikdy rovnakú osobu dvakrát po sebe. Môžeš ručne prepísať vyššie.</value></data>
   <data name="Admin_RerollAll" xml:space="preserve"><value>🎲 Prerollovať</value></data>
   <data name="Admin_RerollOne" xml:space="preserve"><value>Prerollovať upratovanie pre túto kávu</value></data>
+  <data name="Admin_RandomBlend" xml:space="preserve"><value>Pridať náhodnú kávu (vyrovnáva dávky dodávateľov za 30 dní)</value></data>
+  <data name="Admin_RandomBlend_Tea" xml:space="preserve"><value>Pridať náhodný čaj (vyrovnáva dávky dodávateľov za 30 dní)</value></data>
   <data name="Admin_AddBlendBtn" xml:space="preserve"><value>+ Nová káva</value></data>
   <data name="Admin_AddBlendBtn_Tea" xml:space="preserve"><value>+ Nový čaj</value></data>
   <data name="Admin_InviteBtn" xml:space="preserve"><value>+ Pozvať</value></data>

--- a/src/Kavopici.Web/wwwroot/css/app.css
+++ b/src/Kavopici.Web/wwwroot/css/app.css
@@ -716,7 +716,7 @@ textarea { resize: vertical; min-height: 60px; }
 }
 .stats-table-head, .stats-row {
     display: grid;
-    grid-template-columns: minmax(180px, 1.6fr) 84px 64px 90px 150px 100px;
+    grid-template-columns: minmax(180px, 1.6fr) 84px 64px 90px 90px 150px 100px;
     padding: 10px 14px;
     gap: 10px;
     align-items: center;

--- a/tests/Kavopici.Tests/Services/SessionServiceTests.cs
+++ b/tests/Kavopici.Tests/Services/SessionServiceTests.cs
@@ -624,6 +624,192 @@ public class SessionServiceTests : IDisposable
         Assert.InRange(carolCount, 60, 140);
     }
 
+    // --- AddRandomBlendOfTheDayAsync tests ---
+
+    private async Task<int> SeedHistoricalSessionWithDoseAsync(int blendId, decimal doseMultiplier, DateOnly date, DateTime createdAt)
+    {
+        using var context = _factory.CreateDbContext();
+        var session = new TastingSession
+        {
+            BlendId = blendId,
+            Date = date,
+            IsActive = true,
+            DoseMultiplier = doseMultiplier,
+            CreatedAt = createdAt
+        };
+        context.TastingSessions.Add(session);
+        await context.SaveChangesAsync();
+        return session.Id;
+    }
+
+    [Fact]
+    public async Task AddRandomBlendOfTheDayAsync_AddsSessionToToday()
+    {
+        var supplier = await _userService.CreateUserAsync("Supplier", isAdmin: true);
+        var blend = await _blendService.CreateBlendAsync("Test", "Roaster", null, RoastLevel.Medium, supplier.Id);
+
+        var session = await _sessionService.AddRandomBlendOfTheDayAsync();
+
+        Assert.Equal(blend.Id, session.BlendId);
+        Assert.Equal(DateOnly.FromDateTime(DateTime.Today), session.Date);
+        Assert.True(session.IsActive);
+        Assert.Equal(1.0m, session.DoseMultiplier);
+        Assert.NotNull(session.Blend);
+        Assert.NotNull(session.Blend.Supplier);
+
+        var todaySessions = await _sessionService.GetTodaySessionsAsync();
+        Assert.Single(todaySessions);
+    }
+
+    [Fact]
+    public async Task AddRandomBlendOfTheDayAsync_UsesProvidedDoseMultiplier()
+    {
+        var supplier = await _userService.CreateUserAsync("Supplier", isAdmin: true);
+        await _blendService.CreateBlendAsync("Test", "Roaster", null, RoastLevel.Medium, supplier.Id);
+
+        var session = await _sessionService.AddRandomBlendOfTheDayAsync(2m);
+
+        Assert.Equal(2m, session.DoseMultiplier);
+    }
+
+    [Fact]
+    public async Task AddRandomBlendOfTheDayAsync_RejectsInvalidDoseMultiplier()
+    {
+        var supplier = await _userService.CreateUserAsync("Supplier", isAdmin: true);
+        await _blendService.CreateBlendAsync("Test", "Roaster", null, RoastLevel.Medium, supplier.Id);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _sessionService.AddRandomBlendOfTheDayAsync(1.5m));
+    }
+
+    [Fact]
+    public async Task AddRandomBlendOfTheDayAsync_ThrowsWhenNoActiveBlends()
+    {
+        await _userService.CreateUserAsync("Supplier", isAdmin: true);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _sessionService.AddRandomBlendOfTheDayAsync());
+    }
+
+    [Fact]
+    public async Task AddRandomBlendOfTheDayAsync_ExcludesBlendsAlreadyAddedToday()
+    {
+        var supplier = await _userService.CreateUserAsync("Supplier", isAdmin: true);
+        var blendA = await _blendService.CreateBlendAsync("A", "Roaster", null, RoastLevel.Medium, supplier.Id);
+        var blendB = await _blendService.CreateBlendAsync("B", "Roaster", null, RoastLevel.Medium, supplier.Id);
+
+        // A is already on today's list — picker should always choose B.
+        await _sessionService.AddBlendOfTheDayAsync(blendA.Id);
+
+        for (int i = 0; i < 30; i++)
+        {
+            var session = await _sessionService.AddRandomBlendOfTheDayAsync();
+            Assert.Equal(blendB.Id, session.BlendId);
+            // Clean up so the next iteration sees the same starting state.
+            await _sessionService.RemoveBlendOfTheDayAsync(session.Id);
+        }
+    }
+
+    [Fact]
+    public async Task AddRandomBlendOfTheDayAsync_FallsBackWhenAllBlendsAlreadyOnToday()
+    {
+        var supplier = await _userService.CreateUserAsync("Supplier", isAdmin: true);
+        var blend = await _blendService.CreateBlendAsync("Only", "Roaster", null, RoastLevel.Medium, supplier.Id);
+
+        await _sessionService.AddBlendOfTheDayAsync(blend.Id);
+
+        // The only blend is already used today — should still succeed and pick that blend.
+        var session = await _sessionService.AddRandomBlendOfTheDayAsync();
+        Assert.Equal(blend.Id, session.BlendId);
+    }
+
+    [Fact]
+    public async Task AddRandomBlendOfTheDayAsync_BiasesAwayFromHighDoseSuppliers()
+    {
+        var supplierHigh = await _userService.CreateUserAsync("SupplierHigh", isAdmin: true);
+        var supplierLow = await _userService.CreateUserAsync("SupplierLow");
+        var blendHigh = await _blendService.CreateBlendAsync("HighBlend", "Roaster", null, RoastLevel.Medium, supplierHigh.Id);
+        var blendLow = await _blendService.CreateBlendAsync("LowBlend", "Roaster", null, RoastLevel.Medium, supplierLow.Id);
+
+        var today = DateOnly.FromDateTime(DateTime.Today);
+        // SupplierHigh has accumulated 20 dose-equivalents in the window (5 sessions × 4× dose).
+        for (int i = 0; i < 5; i++)
+            await SeedHistoricalSessionWithDoseAsync(blendHigh.Id, 4m, today.AddDays(-10), DateTime.UtcNow.AddDays(-10).AddSeconds(i));
+
+        // Roll many times and tally picks. Weights: high = 1/(1+20) ≈ 0.048, low = 1/(1+0) = 1.0.
+        // Expected P(low) ≈ 0.954. Loose lower bound to avoid flakiness.
+        int highCount = 0, lowCount = 0;
+        for (int i = 0; i < 200; i++)
+        {
+            var session = await _sessionService.AddRandomBlendOfTheDayAsync();
+            if (session.BlendId == blendHigh.Id) highCount++;
+            else if (session.BlendId == blendLow.Id) lowCount++;
+            await _sessionService.RemoveBlendOfTheDayAsync(session.Id); // reset today-exclusion
+        }
+
+        Assert.True(lowCount > 170, $"Low-dose supplier's blend should be picked >85% of the time, got {lowCount}/200.");
+        Assert.True(highCount < 30, $"High-dose supplier's blend should be picked <15% of the time, got {highCount}/200.");
+    }
+
+    [Fact]
+    public async Task AddRandomBlendOfTheDayAsync_SingleHighDoseOutweighsMultipleLowDoses()
+    {
+        // Demonstrates the dose-vs-count distinction: one 4× session contributes more
+        // to the supplier's weight than four 1× sessions from a different supplier.
+        var supplierA = await _userService.CreateUserAsync("SupplierA", isAdmin: true);
+        var supplierB = await _userService.CreateUserAsync("SupplierB");
+        var blendA = await _blendService.CreateBlendAsync("A", "Roaster", null, RoastLevel.Medium, supplierA.Id);
+        var blendB = await _blendService.CreateBlendAsync("B", "Roaster", null, RoastLevel.Medium, supplierB.Id);
+
+        var today = DateOnly.FromDateTime(DateTime.Today);
+        // SupplierA: one 4× session → total dose = 4.
+        await SeedHistoricalSessionWithDoseAsync(blendA.Id, 4m, today.AddDays(-5), DateTime.UtcNow.AddDays(-5));
+        // SupplierB: three 1× sessions → total dose = 3.
+        for (int i = 0; i < 3; i++)
+            await SeedHistoricalSessionWithDoseAsync(blendB.Id, 1m, today.AddDays(-3), DateTime.UtcNow.AddDays(-3).AddSeconds(i));
+
+        // A's weight = 1/5 = 0.2. B's weight = 1/4 = 0.25. P(A) ≈ 44.4%, P(B) ≈ 55.6%.
+        // Even though A has fewer sessions (1 vs 3), A's higher total dose makes it less likely.
+        int aCount = 0, bCount = 0;
+        for (int i = 0; i < 400; i++)
+        {
+            var session = await _sessionService.AddRandomBlendOfTheDayAsync();
+            if (session.BlendId == blendA.Id) aCount++;
+            else if (session.BlendId == blendB.Id) bCount++;
+            await _sessionService.RemoveBlendOfTheDayAsync(session.Id);
+        }
+
+        Assert.True(bCount > aCount,
+            $"B (lower total dose, more sessions) should still be picked more than A (higher total dose, fewer sessions). Got A={aCount}, B={bCount}.");
+    }
+
+    [Fact]
+    public async Task AddRandomBlendOfTheDayAsync_IgnoresDosesOutside30DayWindow()
+    {
+        var supplierOld = await _userService.CreateUserAsync("SupplierOld", isAdmin: true);
+        var supplierNew = await _userService.CreateUserAsync("SupplierNew");
+        var blendOld = await _blendService.CreateBlendAsync("Old", "Roaster", null, RoastLevel.Medium, supplierOld.Id);
+        var blendNew = await _blendService.CreateBlendAsync("New", "Roaster", null, RoastLevel.Medium, supplierNew.Id);
+
+        var today = DateOnly.FromDateTime(DateTime.Today);
+        // SupplierOld accumulated 100 dose-units, but 60 days ago — outside the window, so weight should be equal.
+        for (int i = 0; i < 25; i++)
+            await SeedHistoricalSessionWithDoseAsync(blendOld.Id, 4m, today.AddDays(-60), DateTime.UtcNow.AddDays(-60).AddSeconds(i));
+
+        int oldCount = 0, newCount = 0;
+        for (int i = 0; i < 200; i++)
+        {
+            var session = await _sessionService.AddRandomBlendOfTheDayAsync();
+            if (session.BlendId == blendOld.Id) oldCount++;
+            else if (session.BlendId == blendNew.Id) newCount++;
+            await _sessionService.RemoveBlendOfTheDayAsync(session.Id);
+        }
+
+        // Each ~50%; loose bound 30-70% to avoid flakiness.
+        Assert.InRange(oldCount, 60, 140);
+        Assert.InRange(newCount, 60, 140);
+    }
+
     // --- DoseMultiplier tests ---
 
     [Fact]


### PR DESCRIPTION
## Summary

Three Admin/Stats improvements bundled together (each is its own commit):

- **`f1a2e36` Random blend-of-the-day picker** — a 🎲 button in the Admin "Add from library" panel adds a blend weighted inversely by each supplier's summed dose multipliers over the last 30 days, so suppliers whose coffees have been brewed less recently are favored. Mirrors the existing cleanup-person randomizer pattern; excludes blends already on today's session list. Adds `ISessionService.AddRandomBlendOfTheDayAsync(decimal)`, three localization keys (cs/en/de/sk + `_Tea` variant for the button), and 9 unit tests.
- **`83dbaae` Price-per-star column** restored to the blend overview table on the Statistics page. Adds the `pps` option to the sort dropdown (using the existing `Label_PricePerStar` key and the existing `BlendStatistics.PricePerformance` value), a new column in the grid header/body, and widens `.stats-table-head, .stats-row` in `app.css` to fit the extra 90px slot.
- **`e90782c` Sortable columns** added to three tables: the Library blends table and the Users table on the Admin page, and the Suppliers table on the Statistics page. Each follows the same pattern already used by the user table on Statistics (clickable `<th class="sortable">`, toggle direction on repeated click, ↑/↓ indicator). Sort happens client-side over the already-loaded list.
